### PR TITLE
Customize display of template parameters in Visual Studio and dotnet CLI

### DIFF
--- a/src/ParticularTemplates/Handler/.template.config/dotnetcli.host.json
+++ b/src/ParticularTemplates/Handler/.template.config/dotnetcli.host.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "messagetype": {
+      "shortName": "mt"
+    }
+  }
+}

--- a/src/ParticularTemplates/Handler/.template.config/ide.host.json
+++ b/src/ParticularTemplates/Handler/.template.config/ide.host.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json.schemastore.org/vs-2017.3.host",
+  "name": {
+    "text": "NServiceBus Saga"
+  },
+  "description": {
+    "text": "An NServiceBus saga class pre-populated with two message types and a timeout"
+  },
+  "order": 1,
+  "defaultPersistenceScope": "shared",
+  "defaultPersistenceScopeName": "ParticularSoftware",
+  "symbolInfo": [
+    {
+      "id": "messagetype",
+      "name": {
+        "text": "Message Type"
+      }
+    }
+  ]
+}

--- a/src/ParticularTemplates/Handler/.template.config/template.json
+++ b/src/ParticularTemplates/Handler/.template.config/template.json
@@ -3,7 +3,8 @@
   "author": "Particular Software",
   "classifications": [
     "NServiceBus",
-    "Code"
+    "Code",
+    "General"
   ],
   "name": "NServiceBus Message Handler",
   "identity": "NServiceBus.Handler",

--- a/src/ParticularTemplates/NServiceBusEndpoint/.template.config/dotnetcli.host.json
+++ b/src/ParticularTemplates/NServiceBusEndpoint/.template.config/dotnetcli.host.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "transport": {
+      "shortName": "t"
+    },
+    "persistence": {
+      "shortName": "p"
+    },
+    "hosting": {
+      "shortName": "hm"
+    }
+  }
+}

--- a/src/ParticularTemplates/NServiceBusEndpoint/.template.config/ide.host.json
+++ b/src/ParticularTemplates/NServiceBusEndpoint/.template.config/ide.host.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "http://json.schemastore.org/vs-2017.3.host",
+  "order": 0,
+  "defaultPersistenceScope": "shared",
+  "defaultPersistenceScopeName": "ParticularSoftware",
+  "symbolInfo": [
+    {
+      "id": "transport",
+      "name": {
+        "text": "Message Transport"
+      },
+      "choices": [
+        {
+          "id": "LearningTransport",
+          "name": {
+            "text": "Learning Transport (non-production)"
+          }
+        },
+        {
+          "id": "AzureServiceBus",
+          "name": {
+            "text": "Azure Service Bus"
+          }
+        },
+        {
+          "id": "AzureStorageQueues",
+          "name": {
+            "text": "Azure Storage Queues"
+          }
+        },
+        {
+          "id": "SQS",
+          "name": {
+            "text": "Amazon SQS"
+          }
+        },
+        {
+          "id": "RabbitMQ",
+          "name": {
+            "text": "RabbitMQ"
+          }
+        },
+        {
+          "id": "SQL",
+          "name": {
+            "text": "Microsoft SQL Server"
+          }
+        }
+      ]
+    },
+    {
+      "id": "persistence",
+      "name": {
+        "text": "Data Persistence"
+      },
+      "choices": [
+        {
+          "id": "LearningPersistence",
+          "name": {
+            "text": "Learning Persistence (non-production)"
+          }
+        },
+        {
+          "id": "SQL",
+          "name": {
+            "text": "SQL (MSSQL, PostgreSQL, MySQL, or Oracle)"
+          }
+        },
+        {
+          "id": "CosmosDB",
+          "name": {
+            "text": "Azure Cosmos DB"
+          }
+        },
+        {
+          "id": "AzureTable",
+          "name": {
+            "text": "Azure Table Storage"
+          }
+        },
+        {
+          "id": "RavenDB",
+          "name": {
+            "text": "RavenDB"
+          }
+        },
+        {
+          "id": "MongoDB",
+          "name": {
+            "text": "MongoDB"
+          }
+        },
+        {
+          "id": "DynamoDB",
+          "name": {
+            "text": "Amazon DynamoDB"
+          }
+        },
+        {
+          "id": "NonDurable",
+          "name": {
+            "text": "NonDurable Storage"
+          }
+        }
+      ]
+    },
+    {
+      "id": "hosting",
+      "name": {
+        "text": "Hosting Model"
+      },
+      "choices": [
+        {
+          "id": "ConsoleApp",
+          "name": {
+            "text": "Console Application"
+          }
+        },
+        {
+          "id": "WindowsService",
+          "name": {
+            "text": "Windows Service"
+          }
+        },
+        {
+          "id": "Docker",
+          "name": {
+            "text": "Docker Container"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/ParticularTemplates/Saga/.template.config/dotnetcli.host.json
+++ b/src/ParticularTemplates/Saga/.template.config/dotnetcli.host.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "messagetype1": {
+      "shortName": "mt1"
+    },
+    "messagetype2": {
+      "shortName": "mt2"
+    }
+  }
+}

--- a/src/ParticularTemplates/Saga/.template.config/ide.host.json
+++ b/src/ParticularTemplates/Saga/.template.config/ide.host.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json.schemastore.org/vs-2017.3.host",
+  "name": {
+    "text": "NServiceBus Saga"
+  },
+  "description": {
+    "text": "An NServiceBus saga class pre-populated with two message types and a timeout"
+  },
+  "order": 2,
+  "defaultPersistenceScope": "shared",
+  "defaultPersistenceScopeName": "ParticularSoftware",
+  "symbolInfo": [
+    {
+      "id": "messagetype1",
+      "name": {
+        "text": "Message Type 1"
+      }
+    },
+    {
+      "id": "messagetype2",
+      "name": {
+        "text": "Message Type 2"
+      }
+    }
+  ]
+}

--- a/src/ParticularTemplates/Saga/.template.config/template.json
+++ b/src/ParticularTemplates/Saga/.template.config/template.json
@@ -3,7 +3,8 @@
   "author": "Particular Software",
   "classifications": [
     "NServiceBus",
-    "Code"
+    "Code",
+    "General"
   ],
   "name": "NServiceBus Saga",
   "identity": "NServiceBus.Saga",


### PR DESCRIPTION
With the addition of `ide.host.json` files for templates, the endpoint template now looks like this in Visual Studio:

<img width="1060" alt="image" src="https://github.com/Particular/dotnetTemplates/assets/427110/ce745d75-116e-4ff1-ae28-6b6414269a7c">

Unfortunately, item templates are [not yet supported](https://github.com/dotnet/templating/issues/4686#issuecomment-1574080637) in the Visual Studio New Item dialog.

The addition of `dotnetcli.host.json` files customizes the short parameter names for the templates, such as here in the saga template:

<img width="1280" alt="image" src="https://github.com/Particular/dotnetTemplates/assets/427110/01f7d1ba-4fa6-4f55-9b42-d9be0d73a1e7">
